### PR TITLE
Adding optional encoding in upload_input & path specification for cookies

### DIFF
--- a/libs/utils/ezjs_cookie.ml
+++ b/libs/utils/ezjs_cookie.ml
@@ -13,7 +13,12 @@ let all () =
       | [] -> ("", "")
   ) list
 
-let set key value =
+let path_str =
+  function
+  | None -> ""
+  | Some p -> Format.sprintf "path=%s;" p
+
+let set ?path key value =
   let today = new%js Js.date_now in
   let expire_date = new%js Js.date_ms
       (today##getFullYear + 1) (today##getMonth) (today##getDay)
@@ -21,15 +26,15 @@ let set key value =
       (today##getMilliseconds) in
   let expire_time = Js.to_string expire_date##toUTCString in
   Dom_html.document##.cookie :=
-    Js.string (Printf.sprintf "%s=%s;expires=%s" key value expire_time)
+    Js.string (Printf.sprintf "%s=%s;expires=%s;%s" key value expire_time (path_str path))
 
-let set_with_timeout key value date =
+let set_with_timeout ?path key value date =
   let expire_time = Js.to_string date##toUTCString in
   Dom_html.document##.cookie :=
-    Js.string (Printf.sprintf "%s=%s;expires=%s" key value expire_time)
+    Js.string (Printf.sprintf "%s=%s;expires=%s;%s" key value expire_time (path_str path))
 
 
-let clear key =
+let clear ?path key =
   Dom_html.document##.cookie :=
-    Js.string (Printf.sprintf "%s=;expires=%s" key
-                              "Thu, 01 Jan 1970 00:00:00 UTC")
+    Js.string (Printf.sprintf "%s=;expires=%s;%s" key
+                              "Thu, 01 Jan 1970 00:00:00 UTC" (path_str path))

--- a/libs/utils/ezjs_cookie.mli
+++ b/libs/utils/ezjs_cookie.mli
@@ -5,9 +5,9 @@ type value = string
 val all : unit -> (key * value) list
 
 (** Sets browser cookies. Expiration time is one year by default. *)
-val set : key -> value -> unit
+val set : ?path : string -> key -> value -> unit
 
 (** Sets browser cookies with expiration time. *)
-val set_with_timeout : key -> value -> Js_of_ocaml.Js.date Js_of_ocaml.Js.t -> unit
+val set_with_timeout : ?path : string -> key -> value -> Js_of_ocaml.Js.date Js_of_ocaml.Js.t -> unit
 
-val clear : key -> unit
+val clear : ?path : string -> key -> unit

--- a/libs/utils/ezjs_tyxml.ml
+++ b/libs/utils/ezjs_tyxml.ml
@@ -402,7 +402,7 @@ module Manip = struct
                (fun () -> acc)
                (fun file -> file :: acc)) [] l)
 
-  let upload_input ?(btoa=true) elt post =
+  let upload_input ?(btoa=true) ?encoding elt post =
     let files = files elt in
     List.iter (fun file ->
         let reader = new%js File.fileReader in
@@ -418,7 +418,10 @@ module Manip = struct
                        post s);
               _true
             );
-        reader##(readAsBinaryString file);) files;
+        match encoding with
+          | None -> reader##(readAsBinaryString file)
+          | Some e -> reader##(readAsText_withEncoding file (Js.string e))
+    ) files;
     true
 
   module Elt = struct

--- a/libs/utils/ezjs_tyxml.mli
+++ b/libs/utils/ezjs_tyxml.mli
@@ -101,7 +101,7 @@ module Manip : sig
   val blur: 'a elt -> unit
 
   val files: 'a elt -> File.file t list
-  val upload_input: ?btoa:bool -> 'a elt -> (string -> unit) -> bool
+  val upload_input: ?btoa:bool -> ?encoding:string -> 'a elt -> (string -> unit) -> bool
 
   val scrollIntoView : ?bottom:bool -> 'a Html.elt -> unit
 


### PR DESCRIPTION
Reading an input as a raw string may fail to properly encode strings. For example, accents (é, è, ...) are discarded. This PR allows to add an optional encoding to the input.